### PR TITLE
use readline + history

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ file(GLOB_RECURSE HEADER_FILES include/*.h)
 cmake_policy(SET CMP0144 NEW) # Find package uses upper-case <PACKAGENAME>_ROOT
 cmake_policy(SET CMP0167 NEW) # Use modern Boost CMake package
 
-# Find and link Boost
-find_package(Boost REQUIRED COMPONENTS filesystem)
+# boost library 
+find_package(Boost REQUIRED COMPONENTS filesystem) # Find and link Boost
 
 # Ensure Boost is found
 if(Boost_FOUND)
@@ -34,14 +34,21 @@ else()
     message(FATAL_ERROR "Boost not found!")
 endif()
 
-# Add executable
-add_executable(lmkdb ${SOURCE_FILES})
+add_executable(lmkdb ${SOURCE_FILES}) # Add executable
+target_link_libraries(lmkdb PUBLIC Boost::filesystem) # Link Boost libraries
+target_include_directories(lmkdb PUBLIC ${INCLUDE_PATHS} ${Boost_INCLUDE_DIRS}) # Include directories for the target
 
-# Link Boost libraries
-target_link_libraries(lmkdb PUBLIC Boost::filesystem)
+# readline library
+find_path(READLINE_INCLUDE_DIR readline/readline.h PATHS /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include)
+find_library(READLINE_LIBRARY readline PATHS /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib)
 
-# Include directories for the target
-target_include_directories(lmkdb PUBLIC ${INCLUDE_PATHS} ${Boost_INCLUDE_DIRS})
+if (READLINE_INCLUDE_DIR AND READLINE_LIBRARY)
+	message(STATUS "Readline found: ${READLINE_INCLUDE_DIR}")
+    target_include_directories(lmkdb PRIVATE ${READLINE_INCLUDE_DIR})
+    target_link_libraries(lmkdb PRIVATE ${READLINE_LIBRARY})
+else()
+    message(FATAL_ERROR "Readline not found!")
+endif()
 
 # Add stricter warning options (optional)
 target_compile_options(lmkdb PRIVATE -Wall -Wextra -Wpedantic)

--- a/include/main.h
+++ b/include/main.h
@@ -1,0 +1,17 @@
+// include/main.h
+#ifndef MAIN_H
+#define MAIN_H
+#include <array>
+#include <string_view>
+
+using namespace std;
+
+#ifdef _WIN32
+/* Don't know what the windows equivalent of ~/.config/ is */
+constexpr array<string_view, 2> config_dir = {".config", "lmk"};
+#else
+constexpr array<string_view, 2> config_dir = {".config", "lmk"};
+#endif
+constexpr string_view histfile = ".lmkhistory";
+
+#endif /* MAIN_H */

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,20 +1,67 @@
-#include "Interpreter.h"
+#include "main.h"
+#include <readline/history.h>
+#include <readline/readline.h>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/operations.hpp>
 #include <iostream>
+#include "Interpreter.h"
 
 using namespace std;
 
+boost::filesystem::path get_or_create_cfg_path() {
+#ifdef _WIN32
+    const std::string home(getenv("USERPROFILE"));
+#else
+    const string home(getenv("HOME"));
+#endif
+    boost::filesystem::path cfg_path = home;
+
+    for (auto path : config_dir) {
+        cfg_path /= path; /* boost syntax for path appends */
+    }
+
+    if (!boost::filesystem::exists(cfg_path)) {
+        cout << "initializing cfg dir at " << cfg_path.string() << "\n";
+        boost::filesystem::create_directory(cfg_path);
+    }
+
+    return cfg_path;
+}
+
+void init_lmk() {
+    boost::filesystem::path cfg_path = get_or_create_cfg_path();
+    boost::filesystem::path histpath = cfg_path / histfile;
+    read_history(histpath.c_str());
+}
+
+void exit_lmk() {
+    boost::filesystem::path cfg_path = get_or_create_cfg_path();
+    boost::filesystem::path histpath = cfg_path / histfile;
+    write_history(histpath.c_str());
+}
+
 int main() {
-	Interpreter interpreter;
+    Interpreter interpreter;
+    std::string command;
 
-	std::string command;
-	while (true) {
-		cout << "> ";
-		getline(cin, command);
+    /* initialize lmk*/
+    init_lmk();
 
-		if (command == "exit") { break; }
+    while (true) {
+        command = string(readline("> "));
 
-		interpreter.processCommand(command);
-	}
+        if (command == "exit") {
+            break;
+        }
 
-	return 0;
+        add_history(command.c_str());
+
+        interpreter.processCommand(command);
+    }
+
+    /* cleanup lmk
+     * TODO: call on SIGTERM */
+    exit_lmk();
+
+    return 0;
 }


### PR DESCRIPTION
The readline library supports shell like line reading, including emacs keybindings for navigating through the currently typed input (eg. CTRL+A goes to start of input) and using arrow keys for command history. 

This is great, but requires a history file to store commands between runs, which sort of required a config directory and so here we are